### PR TITLE
refactor: inline single-use variables

### DIFF
--- a/picture.py
+++ b/picture.py
@@ -204,15 +204,14 @@ class Picture:
         else:
             row = row_col
 
-        height, width = self.height, self.width
         count = 0
         if row == 0 or self.__pixels[row - 1, col] != UNKNOWN:
             count += 1
-        if row == height - 1 or self.__pixels[row + 1, col] != UNKNOWN:
+        if row == self.height - 1 or self.__pixels[row + 1, col] != UNKNOWN:
             count += 1
         if col == 0 or self.__pixels[row, col - 1] != UNKNOWN:
             count += 1
-        if col == width - 1 or self.__pixels[row, col + 1] != UNKNOWN:
+        if col == self.width - 1 or self.__pixels[row, col + 1] != UNKNOWN:
             count += 1
 
         return count
@@ -244,12 +243,10 @@ class Picture:
         if self == obj:
             return []
 
-        result = []
-        pixs, pixs2 = self.get_pixels(), obj.get_pixels()
-        indexes = where(pixs != pixs2)
-        differing_values = pixs[indexes]
+        pixs = self.get_pixels()
+        indexes = where(pixs != obj.get_pixels())
         return [(idx[0], idx[1], val)
-                for idx, val in zip(zip(*indexes), differing_values)]
+                for idx, val in zip(zip(*indexes), pixs[indexes])]
 
     def set_all_pixels(self, pixels):
         self.__pixels = pixels

--- a/pool.py
+++ b/pool.py
@@ -6,8 +6,7 @@ from globalvars import Global
 
 def change_pool_size(size=cpu_count() - 1):
     terminate_pool()
-    max_workers = max(cpu_count() - 1, 1)
-    Global.pool_size = min(max(size, 1), max_workers)
+    Global.pool_size = min(max(size, 1), max(cpu_count() - 1, 1))
     Global.pool = Pool(Global.pool_size)
 
 
@@ -20,3 +19,4 @@ def terminate_pool():
 
 def reset_pool():
     change_pool_size(Global.pool_size)
+

--- a/solver.py
+++ b/solver.py
@@ -20,9 +20,7 @@ start_time = time()
 
 
 def clues_valid(rows, cols) -> bool:
-    row_sum = sum(map(sum, rows))
-    col_sum = sum(map(sum, cols))
-    return (row_sum == col_sum
+    return (sum(map(sum, rows)) == sum(map(sum, cols))
             and all(check_line(r, len(cols)) for r in rows)
             and all(check_line(c, len(rows)) for c in cols))
 
@@ -69,10 +67,15 @@ def solve(rows, cols, cheated_pixels=[], drawer=None, lookahead=0):
     for row, col, val in cheated_pixels:
         pic.set_pixel(row, col, val)
 
-    mapped_rows = [(i, states_pregen(x)) for i, x in enumerate(rows)]
-    mapped_cols = [(i, states_pregen(x)) for i, x in enumerate(cols)]
-
-    yield from solve_real(mapped_rows, mapped_cols, pic, 0, [], drawer=drawer, correct_pixels=True, lookahead=lookahead)
+    yield from solve_real(
+        [(i, states_pregen(x)) for i, x in enumerate(rows)],
+        [(i, states_pregen(x)) for i, x in enumerate(cols)],
+        pic,
+        0,
+        [],
+        drawer=drawer,
+        correct_pixels=True,
+        lookahead=lookahead)
 
 
 def solve_one(clue, index, is_col, pic):
@@ -185,19 +188,11 @@ def solve_rows_or_cols(mapped, pic, is_row, correct_pixels=False):
 
 
 def recalculate_pixel_complexities(mapped_rows, mapped_cols, pic):
-    rows = filter(
-        lambda x: pic.get_row_complexity(
-            x[0]) > 1, map(
-            lambda x: (
-                x[0], x[1], True), mapped_rows))
-    cols = filter(
-        lambda x: pic.get_col_complexity(
-            x[0]) > 1, map(
-            lambda x: (
-                x[0], x[1], False), mapped_cols))
-    chained = chain(rows, cols)
-
-    for index, clue, is_row in chained:
+    for index, clue, is_row in chain(
+            filter(lambda x: pic.get_row_complexity(x[0]) > 1,
+                   map(lambda x: (x[0], x[1], True), mapped_rows)),
+            filter(lambda x: pic.get_col_complexity(x[0]) > 1,
+                   map(lambda x: (x[0], x[1], False), mapped_cols))):
         if (is_row and not pic.row_changed_complexity(index)) or (
                 not is_row and not pic.col_changed_complexity(index)):
             continue
@@ -211,13 +206,12 @@ def recalculate_pixel_complexities(mapped_rows, mapped_cols, pic):
                 continue
             line[i] = EMPTY
             new_zero = len_gen_lines(line, clue)
-            new_one = complexity - new_zero
             line[i] = UNKNOWN
             pic.set_pixel_complexity(
                 index if is_row else i,
                 i if is_row else index,
                 zero_complexity=new_zero,
-                one_complexity=new_one
+                one_complexity=complexity - new_zero
             )
 
     pic.store_current_complexities()
@@ -279,24 +273,19 @@ def solve_contra_real(
         max_lookahead=0):
     if min_neighs == 4 and not lookaheading:
         recalculate_pixel_complexities(mapped_rows, mapped_cols, pic)
-        indexed = (
-            (value, (index[0], index[1]), index[2])
-            for index, value in ndenumerate(pic.pixel_complexity) if value != iinfo(int64).max
-        )
         sorted_list = sorted(
-            indexed, key=lambda x: (-(pic.pixel_gain[x[1][0], x[1][1], x[2]] + 1), x[0]))
+            ((value, (index[0], index[1]), index[2])
+             for index, value in ndenumerate(pic.pixel_complexity)
+             if value != iinfo(int64).max),
+            key=lambda x: (-(pic.pixel_gain[x[1][0], x[1][1], x[2]] + 1), x[0]))
         tested = full((pic.height, pic.width, 2), False, dtype=bool)
 
-    rjust_val_rows = 1 + int(log10(pic.height))
-    rjust_val_cols = 1 + int(log10(pic.width))
     len_sorted = len(sorted_list)
-    pic_size = pic.get_pixels().size
     new_filled = filled = pic.count_matching_pixels(lambda x: x != UNKNOWN)
     sorted_list = sorted(
         sorted_list, key=lambda x: (-(pic.pixel_gain[x[1][0], x[1][1], x[2]] + 1), x[0]))
 
-    for i, val in enumerate(sorted_list):
-        comp, index, value = val
+    for i, (_, index, value) in enumerate(sorted_list):
 
         if pic.get_pixel(index) != UNKNOWN or pic.count_neighbours(
                 index) < min_neighs or tested[index[0], index[1], value]:
@@ -308,11 +297,7 @@ def solve_contra_real(
         pic2.set_should_solve_row(index[0], True)
         pic2.set_should_solve_col(index[1], True)
         new_back_progress = back_progress + [
-            f"{
-                pic.count_neighbours(index)}r{
-                index[0]:>{rjust_val_rows}}c{
-                index[1]:>{rjust_val_cols}}: {
-                    i / len_sorted:>3.0%}",
+            f'{pic.count_neighbours(index)}r{index[0]:>{1 + int(log10(pic.height))}}c{index[1]:>{1 + int(log10(pic.width))}}: {i / len_sorted:>3.0%}',
             i,
             len_sorted]
         pic2 = next(
@@ -333,24 +318,21 @@ def solve_contra_real(
                 for diff in (pic2 - pic):
                     tested[diff] = True
                 if lookahead > 0:
-                    pic3 = next(
-                        solve_contra_real(
-                            mapped_rows,
-                            mapped_cols,
-                            pic2,
-                            depth,
-                            new_back_progress,
-                            4,
-                            sorted_list,
-                            tested.copy(),
-                            drawer,
-                            lookahead - 1,
-                            True,
-                            max_lookahead),
-                        None)
-                    # if pic2 has no solutions
-                    if pic3 is None:
-                        # set opposite pixel
+                    if next(
+                            solve_contra_real(
+                                mapped_rows,
+                                mapped_cols,
+                                pic2,
+                                depth,
+                                new_back_progress,
+                                4,
+                                sorted_list,
+                                tested.copy(),
+                                drawer,
+                                lookahead - 1,
+                                True,
+                                max_lookahead),
+                            None) is None:
                         pic.set_pixel(index, value ^ 1)
                         pic.set_should_solve_row(index[0], True)
                         pic.set_should_solve_col(index[1], True)
@@ -365,11 +347,9 @@ def solve_contra_real(
                                 drawer=drawer),
                             None)
 
-                        # even that has no solution
                         if pic is None:
                             return
 
-                        # solution was actually found
                         if pic.is_solved():
                             yield pic
                             return
@@ -377,7 +357,7 @@ def solve_contra_real(
                         new_filled = pic.count_matching_pixels(
                             lambda x: x != UNKNOWN)
 
-                        if min_neighs <= 2 and filled + pic_size / 25 <= new_filled:
+                        if min_neighs <= 2 and filled + pic.get_pixels().size / 25 <= new_filled:
                             break
                 continue
             else:
@@ -406,7 +386,7 @@ def solve_contra_real(
 
         new_filled = pic.count_matching_pixels(lambda x: x != UNKNOWN)
 
-        if (min_neighs <= 2 and filled + pic_size / 25 <=
+        if (min_neighs <= 2 and filled + pic.get_pixels().size / 25 <=
                 new_filled) or (lookaheading and new_filled != filled):
             break
 
@@ -427,8 +407,6 @@ def solve_contra_real(
         yield pic
         return
     yield from solve_real(mapped_rows, mapped_cols, pic, depth + 1, back_progress, drawer=drawer, lookahead=lookahead)
-
-
 def solve_backtrack(
         mapped_rows,
         mapped_cols,
@@ -441,23 +419,29 @@ def solve_backtrack(
     sorted_list = sorted(sorted_list, key=lambda x: -
                          (pic.pixel_gain[x[1][0], x[1][1], x[2]] + 1))
 
-    for i, val in enumerate(sorted_list):
-        comp, index, value = val
+    for _, index, value in sorted_list:
         if pic.get_pixel(index) != UNKNOWN:
             continue
         break
 
-    rjust_val_rows = 1 + int(log10(pic.height))
-    rjust_val_cols = 1 + int(log10(pic.width))
-    new_sols = [value, value ^ 1]
     row, col = index
 
-    for k, val in enumerate(new_sols):
+    for k, val in enumerate([value, value ^ 1]):
         pic2 = pic.copy_pic()
         pic2.set_pixel(index, val)
         pic2.cols_to_solve[col] = True
         pic2.rows_to_solve[row] = True
-        yield from solve_real(mapped_rows, mapped_cols, pic2, depth, back_progress + [f" r{row:>{rjust_val_rows}d}c{col:>{rjust_val_cols}d}: {f'{k / 2:.0%}':>3}", k, 2], drawer=drawer, lookahead=lookahead)
+        yield from solve_real(
+            mapped_rows,
+            mapped_cols,
+            pic2,
+            depth,
+            back_progress + [
+                f" r{row:>{1 + int(log10(pic.height))}d}c{col:>{1 + int(log10(pic.width))}d}: {f'{k / 2:.0%}':>3}",
+                k,
+                2],
+            drawer=drawer,
+            lookahead=lookahead)
 
 
 def solve_check(pic, mapped_rows, mapped_cols, total=False) -> bool:
@@ -492,18 +476,12 @@ def solve_check(pic, mapped_rows, mapped_cols, total=False) -> bool:
 
 def solve_folder(loc, lookahead=0) -> None:
     start = time()
-    only_files = sorted(join(loc, f)
-                        for f in listdir(loc) if isfile(join(loc, f)))
-
-    for file in only_files:
+    for file in sorted(join(loc, f)
+                        for f in listdir(loc) if isfile(join(loc, f))):
         reset_pool()
         solve_file(file, lookahead=lookahead)
 
-    print(
-        f"\nAll from {loc} on {
-            Global.pool_size} threads: {
-            time() -
-            start}\n")
+    print(f"\nAll from {loc} on {Global.pool_size} threads: {time() - start}\n")
 
 
 def solve_file(
@@ -529,10 +507,6 @@ def solve_file(
         # save_picture(pic, f'{location}.{i}')
         if i == number:
             break
-    print(
-        f"{location} on {
-            Global.pool_size} threads: {
-            time() -
-            start}, found {i} solutions")
+    print(f"{location} on {Global.pool_size} threads: {time() - start}, found {i} solutions")
 
     return i

--- a/webpbn.py
+++ b/webpbn.py
@@ -23,25 +23,20 @@ def parse_clues(xml_data):
     root = ET.parse(StringIO(xml_data)).getroot()
 
     # Check if colors are black and white only
-    colors = root.findall(".//color")
-    valid_colors = {'black', 'white'}
-    for color in colors:
-        if color.get('name') not in valid_colors:
+    for color in root.findall(".//color"):
+        if color.get('name') not in {'black', 'white'}:
             return None
 
     # Initialize formatted strings for rows and columns
     rows_formatted = ""
     columns_formatted = ""
 
-    # Find the clues section
-    clues = root.findall(".//clues")
-
-    for clue in clues:
+    # Find and process clues
+    for clue in root.findall(".//clues"):
         # Extract and format each line
         formatted_clue = ""
         for line in clue.findall('./line'):
-            counts = [count.text for count in line.findall('./count')]
-            formatted_clue += ' '.join(counts) + '\n'
+            formatted_clue += ' '.join(count.text for count in line.findall('./count')) + '\n'
 
         # Add to rows or columns
         if clue.get('type') == 'columns':


### PR DESCRIPTION
## Summary
- inline single-use expressions across solver, picture, pool and webpbn modules to reduce temporary variables

## Testing
- `python tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688f4fd27ff88324b7573f1bc9a352d6