### PR TITLE
Remove all type hints

### DIFF
--- a/picture.py
+++ b/picture.py
@@ -1,5 +1,4 @@
-from numpy import ndarray, full, int8, int32, int64, count_nonzero, iinfo, where
-from typing import Optional, Tuple, Union, Callable
+from numpy import full, int8, int32, int64, count_nonzero, iinfo, where
 
 EMPTY = 0
 FULL = 1
@@ -24,50 +23,50 @@ class Picture:
         'correct_pixels')
 
     def __init__(self, height, width, *, generating=True):
-        self.height: int = height
-        self.width: int = width
+        self.height = height
+        self.width = width
 
         if generating:
             self.__pixels = full((height, width), UNKNOWN, dtype=int8)
             self.correct_pixels = full((height, width), False, dtype=bool)
 
-            self.solved_rows: set[int] = set()
-            self.solved_cols: set[int] = set()
+            self.solved_rows = set()
+            self.solved_cols = set()
 
-            self.rows_to_solve: ndarray = full(height, True, dtype=bool)
-            self.cols_to_solve: ndarray = full(width, True, dtype=bool)
+            self.rows_to_solve = full(height, True, dtype=bool)
+            self.cols_to_solve = full(width, True, dtype=bool)
 
-            self.trc: ndarray = full(height, 1, dtype=int64)
-            self.tcc: ndarray = full(width, 1, dtype=int64)
+            self.trc = full(height, 1, dtype=int64)
+            self.tcc = full(width, 1, dtype=int64)
 
-            self.pixel_complexity: ndarray = full(
+            self.pixel_complexity = full(
                 (height, width, 2), iinfo(int64).max, dtype=int64)
 
-            self.pixel_gain: ndarray = full(
+            self.pixel_gain = full(
                 (height, width, 2), iinfo(int32).min, dtype=int32)
 
-            self.old_trc: ndarray = full(height, iinfo(int64).max, dtype=int64)
-            self.old_tcc: ndarray = full(width, iinfo(int64).max, dtype=int64)
+            self.old_trc = full(height, iinfo(int64).max, dtype=int64)
+            self.old_tcc = full(width, iinfo(int64).max, dtype=int64)
 
         else:
-            self.__pixels: Optional[ndarray] = None
+            self.__pixels = None
             self.correct_pixels = None
 
-            self.solved_rows: Optional[set[int]] = None
-            self.solved_cols: Optional[set[int]] = None
+            self.solved_rows = None
+            self.solved_cols = None
 
-            self.rows_to_solve: Optional[ndarray] = None
-            self.cols_to_solve: Optional[ndarray] = None
+            self.rows_to_solve = None
+            self.cols_to_solve = None
 
-            self.trc: Optional[ndarray] = None
-            self.tcc: Optional[ndarray] = None
+            self.trc = None
+            self.tcc = None
 
-            self.pixel_complexity: Optional[ndarray] = None
+            self.pixel_complexity = None
 
-            self.pixel_gain: Optional[ndarray] = None
+            self.pixel_gain = None
 
-            self.old_trc: Optional[ndarray] = None
-            self.old_tcc: Optional[ndarray] = None
+            self.old_trc = None
+            self.old_tcc = None
 
     def __bool__(self):
         raise ValueError("Boolean evaluation is not allowed")
@@ -129,7 +128,7 @@ class Picture:
         self.cols_to_solve[col] = val
 
     def copy_pic(self, *, small=False):
-        pic2: Picture = Picture(self.height, self.width, generating=False)
+        pic2 = Picture(self.height, self.width, generating=False)
         pic2.__pixels = self.__pixels.copy()
         pic2.solved_rows = set(self.solved_rows)
         pic2.solved_cols = set(self.solved_cols)
@@ -171,13 +170,11 @@ class Picture:
         self.__pixels[row, col] = value
 
     def set_pixel_complexity(self,
-                             row_col: Union[Tuple[int,
-                                                  int],
-                                            int],
-                             col: Optional[int] = None,
+                             row_col,
+                             col=None,
                              *,
-                             zero_complexity: Optional[int64] = None,
-                             one_complexity: Optional[int64] = None):
+                             zero_complexity=None,
+                             one_complexity=None):
         if isinstance(row_col, tuple):
             row, col = row_col
         else:
@@ -191,14 +188,14 @@ class Picture:
         if one_complexity is not None and one_complexity < self.pixel_complexity[row, col, 1]:
             self.pixel_complexity[row, col, 1] = one_complexity
 
-    def get_pixels(self) -> ndarray:
+    def get_pixels(self):
         return self.__pixels
 
-    def count_matching_pixels(self, predicate: Callable[[int], bool]) -> int:
+    def count_matching_pixels(self, predicate):
         return count_nonzero(predicate(self.__pixels))
 
     def count_neighbours(
-            self, row_col: Union[Tuple[int, int], int], col: Optional[int] = None) -> int:
+            self, row_col, col=None):
         if isinstance(row_col, tuple):
             row, col = row_col
         else:

--- a/solver.py
+++ b/solver.py
@@ -13,13 +13,12 @@ from numpy import full, int64, ndenumerate, iinfo
 
 setrecursionlimit(10000)
 
-Pixel = int
 EMPTY, FULL, UNKNOWN = 0, 1, 2
 
 start_time = time()
 
 
-def clues_valid(rows, cols) -> bool:
+def clues_valid(rows, cols):
     return (sum(map(sum, rows)) == sum(map(sum, cols))
             and all(check_line(r, len(cols)) for r in rows)
             and all(check_line(c, len(rows)) for c in cols))
@@ -444,7 +443,7 @@ def solve_backtrack(
             lookahead=lookahead)
 
 
-def solve_check(pic, mapped_rows, mapped_cols, total=False) -> bool:
+def solve_check(pic, mapped_rows, mapped_cols, total=False):
     for i, clue in mapped_rows:
         if not total and not pic.rows_to_solve[i]:
             continue
@@ -474,7 +473,7 @@ def solve_check(pic, mapped_rows, mapped_cols, total=False) -> bool:
     return True
 
 
-def solve_folder(loc, lookahead=0) -> None:
+def solve_folder(loc, lookahead=0):
     start = time()
     for file in sorted(join(loc, f)
                         for f in listdir(loc) if isfile(join(loc, f))):

--- a/tests.py
+++ b/tests.py
@@ -1,17 +1,17 @@
 from solver import *
 
 
-def test_easy(drawing=False) -> None:
+def test_easy(drawing=False):
     solve_folder("demo_nonograms/easy/", drawing)
 
 
-def test_medium(drawing=False) -> None:
+def test_medium(drawing=False):
     solve_folder("demo_nonograms/medium/", drawing)
 
 
-def test_pika(drawing=False, cheated_pixels=[]) -> None:
+def test_pika(drawing=False, cheated_pixels=[]):
     solve_file('demo_nonograms/impossible/pikachu', drawing, cheated_pixels)
 
 
-def test_hard(drawing=False) -> None:
+def test_hard(drawing=False):
     solve_folder("demo_nonograms/hard/")

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-from numpy import ndarray, array, int16
+from numpy import array, int16
 
 EMPTY = 0
 FULL = 1


### PR DESCRIPTION
## Summary
- Drop all typing imports and annotations from `Picture`, simplifying attribute setup and helper methods.
- Remove type alias and return annotations from solver and tests for an untyped codebase.
- Tidy unused imports in `utils` after eliminating type hints.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f5502a7a08324a2be424444966acd