### PR TITLE
Avoid mutable default arguments

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -60,7 +60,10 @@ def states_pregen(clue):
     return tuple(states)
 
 
-def solve(rows, cols, cheated_pixels=[], drawer=None, lookahead=0):
+def solve(rows, cols, cheated_pixels=None, drawer=None, lookahead=0):
+    if cheated_pixels is None:
+        cheated_pixels = []
+
     pic = Picture(len(rows), len(cols))
 
     for row, col, val in cheated_pixels:

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,9 @@ def test_medium(drawing=False):
     solve_folder("demo_nonograms/medium/", drawing)
 
 
-def test_pika(drawing=False, cheated_pixels=[]):
+def test_pika(drawing=False, cheated_pixels=None):
+    if cheated_pixels is None:
+        cheated_pixels = []
     solve_file('demo_nonograms/impossible/pikachu', drawing, cheated_pixels)
 
 


### PR DESCRIPTION
## Summary
- Guard against shared state in `solver.solve` by replacing list default argument with `None` and initializing within the function.
- Apply the same pattern in `tests.test_pika` to prevent unintended list reuse.

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f597e1abc8324a97f11aaf1a65270