### PR TITLE
Add PyQt5 drawer for Nonogram progress and solutions

### DIFF
--- a/drawer.py
+++ b/drawer.py
@@ -1,0 +1,139 @@
+import os
+
+# Enable headless mode to allow running without a display
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtWidgets import (
+    QApplication,
+    QLabel,
+    QWidget,
+    QPushButton,
+    QHBoxLayout,
+    QVBoxLayout,
+)
+from PyQt5.QtGui import QPixmap, QImage, QPainter, QColor
+from PyQt5.QtCore import Qt
+
+from constants import EMPTY, FULL, UNKNOWN
+
+
+class QtDrawer:
+    """Simple PyQt5 drawer for the Nonogram solver."""
+
+    def __init__(self, cell_size: int = 20):
+        self.app = QApplication.instance() or QApplication([])
+        self.cell = cell_size
+
+        # dimensions will be initialised on first draw
+        self.height = None
+        self.width = None
+
+        # progress window
+        self.progress_label = QLabel()
+        self.progress_label.setWindowTitle("Progress")
+        self.progress_label.setAlignment(Qt.AlignCenter)
+        self.progress_label.hide()
+
+        # solutions window
+        self.solution_widget = QWidget()
+        self.solution_widget.setWindowTitle("Solutions")
+        self.solution_label = QLabel()
+        self.solution_label.setAlignment(Qt.AlignCenter)
+        self.prev_button = QPushButton("◀")
+        self.next_button = QPushButton("▶")
+        self.prev_button.clicked.connect(self.prev_solution)
+        self.next_button.clicked.connect(self.next_solution)
+        buttons = QHBoxLayout()
+        buttons.addWidget(self.prev_button)
+        buttons.addWidget(self.next_button)
+        layout = QVBoxLayout()
+        layout.addWidget(self.solution_label)
+        layout.addLayout(buttons)
+        self.solution_widget.setLayout(layout)
+        self.solution_widget.hide()
+
+        self.solutions = []  # list of numpy arrays representing solutions
+        self.index = -1
+        self._update_button_visibility()
+
+    # ------------------------------------------------------------------
+    # public API used by solver
+    def update_progress(self, pic):
+        """Update the progress window with the current picture."""
+        self._ensure_size(pic)
+        self.progress_label.setPixmap(self._pixmap_from_picture(pic))
+        self.progress_label.show()
+        self.app.processEvents()
+
+    def add_solution(self, pic):
+        """Store a newly found solution and update the solution window."""
+        self._ensure_size(pic)
+        self.solutions.append(pic.get_pixels().copy())
+        self.index = len(self.solutions) - 1
+        self.solution_widget.show()
+        self._display_current_solution()
+        self.app.processEvents()
+
+    # ------------------------------------------------------------------
+    # navigation callbacks
+    def next_solution(self):
+        if self.index < len(self.solutions) - 1:
+            self.index += 1
+            self._display_current_solution()
+
+    def prev_solution(self):
+        if self.index > 0:
+            self.index -= 1
+            self._display_current_solution()
+
+    # ------------------------------------------------------------------
+    # helpers
+    def _ensure_size(self, pic):
+        if self.height != pic.height or self.width != pic.width:
+            self.height = pic.height
+            self.width = pic.width
+            w, h = self.width * self.cell, self.height * self.cell
+            self.progress_label.resize(w, h)
+            self.solution_label.resize(w, h)
+
+    def _display_current_solution(self):
+        if not self.solutions:
+            return
+        arr = self.solutions[self.index]
+        self.solution_label.setPixmap(self._pixmap_from_array(arr))
+        self._update_button_visibility()
+
+    def _update_button_visibility(self):
+        multiple = len(self.solutions) > 1
+        self.prev_button.setVisible(multiple)
+        self.next_button.setVisible(multiple)
+        self.prev_button.setEnabled(multiple and self.index > 0)
+        self.next_button.setEnabled(multiple and self.index < len(self.solutions) - 1)
+
+    def _pixmap_from_picture(self, pic):
+        return self._pixmap_from_array(pic.get_pixels())
+
+    def _pixmap_from_array(self, arr):
+        h, w = arr.shape
+        img = QImage(w * self.cell, h * self.cell, QImage.Format_RGB32)
+        painter = QPainter(img)
+        colors = {
+            EMPTY: QColor("white"),
+            FULL: QColor("black"),
+            UNKNOWN: QColor("gray"),
+        }
+        for i in range(h):
+            for j in range(w):
+                painter.fillRect(
+                    j * self.cell,
+                    i * self.cell,
+                    self.cell,
+                    self.cell,
+                    colors.get(int(arr[i, j]), QColor("gray")),
+                )
+        painter.end()
+        return QPixmap.fromImage(img)
+
+
+__all__ = ["QtDrawer"]
+

--- a/solver.py
+++ b/solver.py
@@ -136,10 +136,13 @@ def solve_real(
             pic,
             mapped_rows,
             mapped_cols,
-            depth != 0):
+            depth != 0,
+            drawer=drawer):
         return
 
     if pic.is_solved():
+        if hasattr(drawer, "add_solution"):
+            drawer.add_solution(pic)
         yield pic
         return
 
@@ -445,7 +448,7 @@ def solve_backtrack(
             lookahead=lookahead)
 
 
-def solve_check(pic, mapped_rows, mapped_cols, total=False):
+def solve_check(pic, mapped_rows, mapped_cols, total=False, *, drawer=None):
     for i, clue in mapped_rows:
         if not total and not pic.rows_to_solve[i]:
             continue
@@ -472,21 +475,25 @@ def solve_check(pic, mapped_rows, mapped_cols, total=False):
             pic.solved_cols.add(i)
         pic.set_col_complexity(i, complexity)
 
+    if hasattr(drawer, "update_progress"):
+        drawer.update_progress(pic)
+
     return True
 
 
-def solve_folder(loc, lookahead=0):
+def solve_folder(loc, drawer=None, lookahead=0):
     start = time()
     for file in sorted(join(loc, f)
                         for f in listdir(loc) if isfile(join(loc, f))):
         pool_manager.reset_pool()
-        solve_file(file, lookahead=lookahead)
+        solve_file(file, drawer=drawer, lookahead=lookahead)
 
     print(f"\nAll from {loc} on {pool_manager.pool_size} threads: {time() - start}\n")
 
 
 def solve_file(
         location,
+        drawer=None,
         cheated_pixels=None,
         number=-1,
         lookahead=0):
@@ -502,6 +509,7 @@ def solve_file(
             rows,
             cols,
             cheated_pixels=cheated_pixels,
+            drawer=drawer,
             lookahead=lookahead):
         i += 1
         print(f"{i}", end=' ')


### PR DESCRIPTION
## Summary
- Implement a PyQt5-based `QtDrawer` with a progress window and a solutions window including navigation arrows
- Hook the drawer into solving logic to update on every `solve_check` and display each solution
- Allow `solve_file` and `solve_folder` to accept an optional drawer

## Testing
- `python3 -m py_compile solver.py drawer.py`
- `python3 - <<'PY'
from solver import solve_file
from drawer import QtDrawer
qt = QtDrawer()
solve_file('demo_nonograms/easy/10000', drawer=qt, number=1)
PY`


------
https://chatgpt.com/codex/tasks/task_e_688f9f1cc49483249aa61fdd547ea405